### PR TITLE
Padronização de nomenclatura

### DIFF
--- a/src/actions/lumikit/set_bpm_by_trigger_functions.js
+++ b/src/actions/lumikit/set_bpm_by_trigger_functions.js
@@ -2,7 +2,7 @@ function hGetItemInputParams() {
     return [
         {
             id: 'receiver_id',
-            name: 'Lumikit',
+            name: 'Receptor',
             description: '',
             type: 'receiver',
             receiver: 'lumikit'


### PR DESCRIPTION
de:            name: 'Lumikit',
para:            name: 'Receptor',