### PR TITLE
Funções Spotify

### DIFF
--- a/src/includes/ha.js
+++ b/src/includes/ha.js
@@ -111,7 +111,11 @@ function activateTrigger(receiverID, entityID) {
 
 //spotify on ha
 // Function to play a specific music track on a Spotify media player
-function spotifyPlayMusic(receiverID, entityID, mediaID) {
+function spotifyPlayMusic(receiverID, entityID, mediaID, source) {
+    if (source) {
+        spotifySetSource(receiverID, entityID, source);
+        h.sleep(500);
+    }
     var urlSuffix = '/api/services/media_player/play_media';
     var data = {
         entity_id: entityID,

--- a/src/includes/ha.js
+++ b/src/includes/ha.js
@@ -107,3 +107,47 @@ function activateTrigger(receiverID, entityID) {
     var urlSuffix = '/api/services/automation/trigger';
     jsc.ha.request(receiverID, urlSuffix, entityID);
 }
+
+
+//spotify on ha
+// Function to play a specific music track on a Spotify media player
+function spotifyPlayMusic(receiverID, entityID, mediaID) {
+    var urlSuffix = '/api/services/media_player/play_media';
+    var data = {
+        entity_id: entityID,
+        media_content_id: mediaID,
+        media_content_type: 'music'
+    };
+	h.log('jsc.ha', "spotifyPlayMusic({}, {}, {})", [receiverID, entityID, data]);
+    jsc.ha.request(receiverID, urlSuffix, data);
+}
+
+// Function to start playback on a Spotify media player, optionally setting a source first
+function spotifyPlay(receiverID, entityID, source) {
+    if (source) {
+        spotifySetSource(receiverID, entityID, source);
+        h.sleep(500);
+    }
+    var urlSuffix = '/api/services/media_player/media_play';
+    h.log('jsc.ha', "spotifyPlay({}, {}, {})", [receiverID, entityID, source]);
+    jsc.ha.request(receiverID, urlSuffix, entityID);
+}
+
+// Function to set the source of a Spotify media player
+function spotifySetSource(receiverID, entityID, source) {
+    var urlSuffix = '/api/services/media_player/select_source';
+    h.log('jsc.ha', "spotifySetSource({}, {}, {})", [receiverID, entityID, source]);
+    jsc.ha.request(receiverID, urlSuffix, {entity_id: entityID, source: source});
+}
+
+// Function to pause playback on a Spotify media player, optionally setting a source first
+// Note: Although the 'source' parameter is not mandatory, it is often better to include it 
+// to avoid potential errors that may occur when it is omitted.
+function spotifyPause(receiverID, entityID, source) {
+    if (source) {
+        spotifySetSource(receiverID, entityID, source);
+    }
+    var urlSuffix = '/api/services/media_player/media_pause';
+    h.log('jsc.ha', "spotifyPause({}, {}, {})", [receiverID, entityID, source]);
+    jsc.ha.request(receiverID, urlSuffix, entityID);
+}


### PR DESCRIPTION
**Funções para Controle do Spotify**

**Parâmetros iguais entre os comandos:**
receiverID: O ID do receptor de mídia.
entityID: O ID da entidade de mídia no Home Assistant. 
source: (Opcional) A fonte a ser definida antes de iniciar a reprodução. (qual dispositivo é para enviar o comando)

**Funções:**

_spotifyPlayMusic(receiverID, entityID, mediaID)_
Descrição: Reproduz uma faixa de música específica em um reprodutor de mídia Spotify. 
mediaID: O ID do conteúdo de mídia a ser reproduzido. (a url como a do holyrics, exemplo 'https://open.spotify.com/track/5rQgBqryKrQZ1jCLzTp2tz')

_spotifyPlay(receiverID, entityID, source)_
Descrição: Inicia a reprodução em um reprodutor de mídia Spotify. Opcionalmente define a fonte antes da reprodução. Incluir o parâmetro source é recomendado para evitar possíveis erros.

_spotifySetSource(receiverID, entityID, source)_
Descrição: Define a fonte em um reprodutor de mídia Spotify. (em qual dispositivo é para tocar)

_spotifyPause(receiverID, entityID, source)_
Descrição: Pausa a reprodução em um reprodutor de mídia Spotify. Opcionalmente define a fonte antes de pausar. Incluir o parâmetro source é recomendado para evitar possíveis erros.