### PR TITLE
Ajustes de compatibilidade

### DIFF
--- a/src/modules/prcris/#m13 PC unMute Holyrics+.js
+++ b/src/modules/prcris/#m13 PC unMute Holyrics+.js
@@ -48,6 +48,9 @@ function triggers(module) {
       item: "any_" + type, 
       action: (function(type) {
         return function(obj) {
+          if (isModuleSuspended()) {
+             return;
+          }
           var s = module.settings;
           var m1 = s.digital_mixer_id;
           var m2 = s.mixer_channel;

--- a/src/modules/prcris/#m15 Vídeo Sync OBS+ v2.js
+++ b/src/modules/prcris/#m15 Vídeo Sync OBS+ v2.js
@@ -56,7 +56,9 @@ function triggers(module) {
     when: "displaying",
     item: "any_video",
     action: function(obj) {
-
+      if (isModuleSuspended()) {
+         return;
+      }
       obsVideo(module, true, obj.file_fullname);
       module.updatePanel();
     }
@@ -175,7 +177,7 @@ function restorePreviousScene(module) {
 
 function gsJump(value) {
 
-h.log(mUID, "gsJump:{}", value);
+//h.log(mUID, "{%t} gsJump:{}", value);
 
 if (value != undefined) { 
   h.setGlobal(mUID + '_jumpToScene', value == "" ? null : value);
@@ -193,25 +195,25 @@ function obsVideo(module, show, mediaName) {
     pause = false;
     if (!show) { 
         if (gsJump()) {
-            h.log(mUID, "======= Execução de vídeo no OBS interrompida pelo botão de pânico, voltando para a cena {}", gsJump());
+            h.log(mUID, "{%t} ======= Execução de vídeo no OBS interrompida pelo botão de pânico, voltando para a cena {}", gsJump());
             h.notification("Execução de vídeo no OBS interrompida pelo botão de pânico.", 3);
             restorePreviousScene(module); 
         }
         return;
     }
-    h.log(mUID, "exclamation_mark: {} , mediaName: {}", s.exclamation_mark, mediaName);
-    h.log(mUID, "mediaName.indexOf('!') {}", mediaName.indexOf('!'));
+    h.log(mUID, "{%t} exclamation_mark: {} , mediaName: {}", s.exclamation_mark, mediaName);
+    h.log(mUID, "{%t} mediaName.indexOf('!') {}", mediaName.indexOf('!'));
     
     // Se exclamation_mark estiver habilitado, apenas vídeos com "!" no nome serão enviados para o OBS
     if (s.exclamation_mark == 'true' && mediaName.indexOf('!') == -1) {  //caso não possua
-           h.log(mUID, "======= Vídeo não enviado para o OBS por NÃO possuir ! no nome.");
+           h.log(mUID, "{%t} ======= Vídeo não enviado para o OBS por NÃO possuir ! no nome.");
            restorePreviousScene(module);
            return;
     }
     
     // Se exclamation_mark estiver desabilitado, apenas vídeos sem "!" no nome serão enviados para o OBS
     if (s.exclamation_mark == 'false' && mediaName.indexOf('!') > -1) { //caso possua:
-           h.log(mUID, "======= Vídeo não enviado para o OBS por POSSUIR ! no nome.");
+           h.log(mUID, "{%t} ======= Vídeo não enviado para o OBS por POSSUIR ! no nome.");
            restorePreviousScene(module);
            return;
     }
@@ -224,7 +226,7 @@ function obsVideo(module, show, mediaName) {
       return;
     }
 
-    h.log(mUID, "======= Vídeo enviado para o OBS: " + mediaName);
+    h.log(mUID, "{%t} ======= Vídeo enviado para o OBS: " + mediaName);
     
     var previousScene = jsc.obs_v5.getActiveScene(p1);
     
@@ -250,7 +252,7 @@ function obsVideo(module, show, mediaName) {
     
     intervalPauseVLC(module);
    
-    h.log(mUID, "======= Cena ativada no OBS, scene: {}, item_scene: {}, file: {}", [p2, p3, mediaName]);
+    h.log(mUID, "{%t} ======= Cena ativada no OBS, scene: {}, item_scene: {}, file: {}", [p2, p3, mediaName]);
 
 
     // Prepara para retornar à cena original quando o vídeo terminar ou for parado
@@ -259,10 +261,10 @@ function obsVideo(module, show, mediaName) {
             if (jsc.obs_v5.getActiveScene(p1) == p2) { // Caso o botão de pânico tenha sido ativado, não trocar de cena
                h.setTimeout(function() { 
                   if (!isPlaying()) {
-                      h.log(mUID, "======= Vídeo concluído - ativando cena anterior no OBS, scene: {}", [gsJump()]);
+                      h.log(mUID, "{%t} ======= Vídeo concluído - ativando cena anterior no OBS, scene: {}", [gsJump()]);
                       restorePreviousScene(module); 
                       module.updatePanel();
-                      // h.log(mUID, "Retornando cfgs VLC Player: mute: {}, repeat: {}, volume {}", [pMute, pRepeat, pVolume]);
+                      // h.log(mUID, "{%t} Retornando cfgs VLC Player: mute: {}, repeat: {}, volume {}", [pMute, pRepeat, pVolume]);
                       // h.hly('MediaPlayerAction', { mute: pMute, repeat: pRepeat, volume: pVolume });
                       pause = false;
                   }

--- a/src/modules/prcris/#m18 Showtime.js
+++ b/src/modules/prcris/#m18 Showtime.js
@@ -684,6 +684,8 @@ h.log(mUID, "{%t} Tempos em MS de cada evento: {}", h.toPrettyJson(d));
 
 timingCheckAndSet(s,d.c)
 
+suspendConflictingModules(true, [13,15]);  // suspende o módulo de vídeo e de mesa de som
+
 sc(s,d);
 scVideosLocal(s,d);
 if (s.streaming_id != "") {
@@ -783,6 +785,7 @@ if (s[cfg].preservice < totalVideos) {
 }
 
 }
+
 // __SCRIPT_SEPARATOR__ - info:7b226e616d65223a22687562227d
 function setDMX(receiverID, scene, bpm) {
   var str = 'ASDFGHJKLZXCVBNM';
@@ -973,14 +976,15 @@ function timeToStart(milliseconds) {
 
 function cancelShowRunAt() {
     var openingTimers = h.getGlobal(mUID + '_openingServiceTimers') || [];
-
     // Cancel each timer in the list
     for (var i = 0; i < openingTimers.length; i++) {
         h.cancelRunAt(openingTimers[i]);
     }
     // Clear the timer list
     h.setGlobal(mUID + '_openingServiceTimers', []);
-    h.log(mUID, "{%t} All service opening timers have been canceled.");
+    h.log(mUID, "{%t} Todos os agendamentos do módulo foram cancelados.");
+    
+    suspendConflictingModules(false);
 }
 
 function getTimeUntilSchedule(delayMinutes) {  //quanto tempo para encerrar o show baseado na hora de inicio + minutos de atraso
@@ -1091,10 +1095,11 @@ function refreshShowTimeSchedules(module) {
      var timeToStartShow = getFurthestFutureTime(d, s, false);
      var timeToEndShow = getFurthestFutureTime(d, s, true);
      
-     if (timeToStartShow > -1) {
+     if (timeToStartShow - 10000 > -1) {
         setShowRunAt(function() { startSchedulesShow(module); }, timeToStartShow -10000, 'O Show vai iniciar!', true);
         h.notification('Show de abertura programado para iniciar às '+timeToStart(timeToStartShow),5);
      } else {
+        
         h.notification('Já passou do horário mínimo para programação do evento em '+ formatDuration(d.startShow * -1) +'!',5);
      }
 

--- a/src/modules/prcris/lib/modules_generic_functions.js
+++ b/src/modules/prcris/lib/modules_generic_functions.js
@@ -26,3 +26,29 @@ function showMessage(title, message) {
 
     h.input(content);
 }
+
+
+function suspendConflictingModules(status, conflictModules) {
+    if (!status) {
+       conflictModules = h.getGlobal(mID+'ConflictModules') || [];
+    }
+    else
+    {
+      h.setGlobal(mID+'ConflictModules', conflictModules);
+    }
+
+    for (var i = 0; i < conflictModules.length; i++) {
+      var moduleName = '@prcris#m' + conflictModules[i];
+      h.setGlobal('suspendConflictingModules' + moduleName, status);    
+      h.log(mUID,'{%t} Módulo {}{}', moduleName , status ? ' temporariamente suspenso.' : ' reativado.');
+    }   
+}
+
+function isModuleSuspended() {
+    
+    var status = h.getGlobal('suspendConflictingModules' + mID) == true;
+    if (status) {
+       h.log(mUID,'{%t} Módulo {} temporariamente suspenso por outro processo.', mID);
+    }  
+    return status ;
+}


### PR DESCRIPTION
Criada função para desabilitar funcionalidades de outros módulos, neste caso a partir do Showtime. Exemplo, o módulo #m15 não enviará vídeos ao OBS e o #m13 não alterará o volume da mesa de som, deixando tudo a cargo do #m18 Showtime durante a execução de um show.