### PR TITLE
Aprimoramento módulo Video Sync OBS

### DIFF
--- a/src/includes/obs_v5.js
+++ b/src/includes/obs_v5.js
@@ -62,10 +62,17 @@ function getSceneList(receiverID) {
     return names;
 }
 
-// Set the active scene
+// Get the active scene
 function getActiveScene(receiverID) {
     var response = jsc.obs_v5.request(receiverID, 'GetCurrentProgramScene');
     h.log('jsc.obs_v5', 'GetCurrentProgramScene response: {}', response);
+    return response.currentProgramSceneName || response.sceneName;
+}
+
+//  Get the active preview scene
+function getPreviewScene(receiverID) {
+    var response = jsc.obs_v5.request(receiverID, 'GetCurrentPreviewScene');
+    h.log('jsc.obs_v5', 'GetCurrentPreviewScene response: {}', response);
     return response.currentProgramSceneName || response.sceneName;
 }
 

--- a/src/modules/prcris/#m15 Vídeo Sync OBS+ v2.js
+++ b/src/modules/prcris/#m15 Vídeo Sync OBS+ v2.js
@@ -58,7 +58,7 @@ function info() {
                     '• Supports interrupting the video.<br>' +
                     '• Supports sending another video while one is playing, for immediate switching.<br>' +
                     '• When the video ends in Holyrics, it activates the previous scene.<br>' +
-                    '• Has a panic button to stop the video in OBS without interfering with the main screen, activating the previous scene.<br>'+infoVDDMM,
+                    '• Has a panic button to stop the video in OBS without interfering with the main screen, activating the previous scene.<br>',
                 pt: '<html>' +
                     (h.isMinVersion("2.24.0") ? '<span style="background-color: yellow;"><font color="black"><b>##NOVO</b></font></span> Não precisa mais liberar na blacklist_request o SetInputSettings<br>' : '') +
                     '• Exibe um vídeo em uma cena previamente configurada no OBS simultaneamente à exibição no Holyrics.<br>' +
@@ -68,7 +68,7 @@ function info() {
                     '• Aceita interromper o vídeo.<br>' +
                     '• Aceita enviar outro vídeo enquanto um está passando, fazendo a troca imediata.<br>' +
                     '• Quando termina o vídeo no Holyrics, ativa cena anterior.<br>' +
-                    '• Possui botão de pânico para interromper vídeo no OBS sem interferir no telão, ativando a cena anterior.<br>'+infoVDDMM,
+                    '• Possui botão de pânico para interromper vídeo no OBS sem interferir no telão, ativando a cena anterior.<br>',
                 es: '<html>' +
                     (h.isMinVersion("2.24.0") ? '<span style="background-color: yellow;"><font color="black"><b>##NUEVO</b></font></span> No es necesario liberar SetInputSettings en blacklist_request<br>' : '') +
                     '• Muestra un video en una escena preconfigurada en OBS simultáneamente con la visualización en Holyrics.<br>' +
@@ -78,7 +78,7 @@ function info() {
                     '• Soporta interrumpir el video.<br>' +
                     '• Permite enviar otro video mientras se reproduce uno, para cambio inmediato.<br>' +
                     '• Cuando el video termina en Holyrics, activa la escena anterior.<br>' +
-                    '• Tiene un botón de pánico para detener el video en OBS sin interferir en la pantalla principal, activando la escena anterior.<br>'+infoVDDMM,
+                    '• Tiene un botón de pánico para detener el video en OBS sin interferir en la pantalla principal, activando la escena anterior.<br>',
                 ru: '<html>' +
                     (h.isMinVersion("2.24.0") ? '<span style="background-color: yellow;"><font color="black"><b>##НОВОЕ</b></font></span> Не нужно разблокировать SetInputSettings в blacklist_request<br>' : '') +
                     '• Показывает видео на предварительно настроенной сцене в OBS одновременно с показом в Holyrics.<br>' +
@@ -88,7 +88,7 @@ function info() {
                     '• Поддерживает прерывание видео.<br>' +
                     '• Поддерживает отправку другого видео во время воспроизведения одного, для немедленной смены.<br>' +
                     '• Когда видео заканчивается в Holyrics, активируется предыдущая сцена.<br>' +
-                    '• Имеет кнопку экстренного прерывания видео в OBS без вмешательства в основной экран, активируя предыдущую сцену.<br>'+infoVDDMM
+                    '• Имеет кнопку экстренного прерывания видео в OBS без вмешательства в основной экран, активируя предыдущую сцену.<br>'
             }
         }
     };
@@ -140,7 +140,7 @@ function settings() {
         },
         {
             id: 'scene_name',
-            name: jsc.i18n('Scene name'), // Deixei como estava, pois parece que já usa jsc.i18n para isso
+            name: jsc.i18n('Scene name'), 
             description: jsc.i18n('Select the OBS scene to play the video'),
             type: 'string',
             suggested_values: function(obj) {
@@ -156,6 +156,11 @@ function settings() {
                 return jsc.obs_v5.getSceneItemList(obj.input.receiver_id, obj.input.scene_name);
             }
         },
+        {
+            id: 'use_preview_scene',
+            label: jsc.i18n('Use the preview scene when finishing the video'),
+            type: 'boolean'
+        },        
         {
             id: 'exclamation_mark',
             label: jsc.i18n('Send to OBS'),
@@ -224,8 +229,16 @@ function restorePreviousScene(module) {
     var p1 = s.receiver_id;
     var p2 = s.scene_name;
     var p3 = s.scene_item_name;
+    if (module.settings.use_preview_scene) {
+       try {
+       var scene = jsc.obs_v5.getPreviewScene(p1);   
+       h.log(mUID,'{%t} scene {}', scene);  
+       if (scene) {
+         gsJump(scene);   
+       }
+      } catch (err) { h.log(mUID,'Erro {}',[err]) };
+    }
     jsc.obs_v5.setActiveScene(p1, gsJump());
-    //jsc.obs_v5.setSceneItemEnabled(p1, p2, p3, false);
     gsJump("");
 }
 
@@ -252,6 +265,7 @@ function obsVideo(module, show, mediaName) {
         }
         return;
     }
+
     h.log(mUID, "{%t} " + jsc.i18n("exclamation mark") + ": {} , mediaName: {}", [s.exclamation_mark, mediaName]);
     h.log(mUID, "{%t} " + jsc.i18n("media name contains '!'") + ": {}", [mediaName.indexOf('!') !== -1]);
     

--- a/src/modules/prcris/#m15 Vídeo Sync OBS+ v2.js
+++ b/src/modules/prcris/#m15 Vídeo Sync OBS+ v2.js
@@ -58,7 +58,8 @@ function info() {
                     '• Supports interrupting the video.<br>' +
                     '• Supports sending another video while one is playing, for immediate switching.<br>' +
                     '• When the video ends in Holyrics, it activates the previous scene.<br>' +
-                    '• Has a panic button to stop the video in OBS without interfering with the main screen, activating the previous scene.<br>',
+                    '• Has a panic button to stop the video in OBS without interfering with the main screen, activating the previous scene.<br>' +
+                     infoVDDMM,
                 pt: '<html>' +
                     (h.isMinVersion("2.24.0") ? '<span style="background-color: yellow;"><font color="black"><b>##NOVO</b></font></span> Não precisa mais liberar na blacklist_request o SetInputSettings<br>' : '') +
                     '• Exibe um vídeo em uma cena previamente configurada no OBS simultaneamente à exibição no Holyrics.<br>' +
@@ -68,7 +69,8 @@ function info() {
                     '• Aceita interromper o vídeo.<br>' +
                     '• Aceita enviar outro vídeo enquanto um está passando, fazendo a troca imediata.<br>' +
                     '• Quando termina o vídeo no Holyrics, ativa cena anterior.<br>' +
-                    '• Possui botão de pânico para interromper vídeo no OBS sem interferir no telão, ativando a cena anterior.<br>',
+                    '• Possui botão de pânico para interromper vídeo no OBS sem interferir no telão, ativando a cena anterior.<br>' +
+                     infoVDDMM,
                 es: '<html>' +
                     (h.isMinVersion("2.24.0") ? '<span style="background-color: yellow;"><font color="black"><b>##NUEVO</b></font></span> No es necesario liberar SetInputSettings en blacklist_request<br>' : '') +
                     '• Muestra un video en una escena preconfigurada en OBS simultáneamente con la visualización en Holyrics.<br>' +
@@ -78,7 +80,8 @@ function info() {
                     '• Soporta interrumpir el video.<br>' +
                     '• Permite enviar otro video mientras se reproduce uno, para cambio inmediato.<br>' +
                     '• Cuando el video termina en Holyrics, activa la escena anterior.<br>' +
-                    '• Tiene un botón de pánico para detener el video en OBS sin interferir en la pantalla principal, activando la escena anterior.<br>',
+                    '• Tiene un botón de pánico para detener el video en OBS sin interferir en la pantalla principal, activando la escena anterior.<br>' +
+                     infoVDDMM,
                 ru: '<html>' +
                     (h.isMinVersion("2.24.0") ? '<span style="background-color: yellow;"><font color="black"><b>##НОВОЕ</b></font></span> Не нужно разблокировать SetInputSettings в blacklist_request<br>' : '') +
                     '• Показывает видео на предварительно настроенной сцене в OBS одновременно с показом в Holyrics.<br>' +
@@ -88,7 +91,8 @@ function info() {
                     '• Поддерживает прерывание видео.<br>' +
                     '• Поддерживает отправку другого видео во время воспроизведения одного, для немедленной смены.<br>' +
                     '• Когда видео заканчивается в Holyrics, активируется предыдущая сцена.<br>' +
-                    '• Имеет кнопку экстренного прерывания видео в OBS без вмешательства в основной экран, активируя предыдущую сцену.<br>'
+                    '• Имеет кнопку экстренного прерывания видео в OBS без вмешательства в основной экран, активируя предыдущую сцену.<br>' +
+                     infoVDDMM
             }
         }
     };


### PR DESCRIPTION
Criada a configuração de quando termina o vídeo ir para a cena que estiver no preview, no caso das igrejas que usam o preview como base, invés de saltar para a última cena.

Adicionado novo comando na jsc.obs_v5:

function getPreviewScene(receiverID) {